### PR TITLE
Profileコントローラーとそのテストを実装

### DIFF
--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -1,69 +1,62 @@
-module Api
-  module V1
-    class AuthController < ApplicationController
-      skip_before_action :authenticate, only: [:login, :signup]
+class Api::V1::AuthController < ApplicationController
+  skip_before_action :authenticate, only: [:login, :signup]
 
-      def login
-        user = Auth.authenticate(params[:email], params[:password])
-
-        if user
-          token = Auth.encode(user_id: user.id)
-          render json: {
-            token: token,
-            user: {
-              id: user.id,
-              email: user.email,
-              github_username: user.github_username,
-              qiita_username: user.qiita_username
-            }
-          }, status: :ok
-        else
-          render json: { error: I18n.t('auth.errors.invalid_credentials') }, status: :unauthorized
-        end
-      end
-
-      def signup
-        user = User.new(user_params)
-
-        if user.save
-          token = Auth.encode(user_id: user.id)
-          render json: {
-            token: token,
-            user: {
-              id: user.id,
-              email: user.email,
-              github_username: user.github_username,
-              qiita_username: user.qiita_username
-            }
-          }, status: :created
-        else
-          render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
-        end
-      end
-
-      private
-
-      def user_params
-        params.permit(:email, :password, :password_confirmation, :github_username, :qiita_username)
-      end
-
-      # 開発環境用テストアクション
-      def test_token
-        test_user = User.first || User.create(
-          email: 'test@example.com',
-          password: 'password',
-          password_confirmation: 'password'
-        )
-        token = Auth.encode(user_id: test_user.id)
-
-        render json: {
-          token: token,
-          user: {
-            id: test_user.id,
-            email: test_user.email
-          }
-        }, status: :ok
-      end
+  def login
+    user = Auth.authenticate(params[:email], params[:password])
+    if user
+      token = Auth.encode(user_id: user.id)
+      render json: {
+        token: token,
+        user: {
+          id: user.id,
+          email: user.email,
+          github_username: user.github_username,
+          qiita_username: user.qiita_username
+        }
+      }, status: :ok
+    else
+      render json: { error: I18n.t('auth.errors.invalid_credentials') }, status: :unauthorized
     end
+  end
+
+  def signup
+    user = User.new(user_params)
+    if user.save
+      token = Auth.encode(user_id: user.id)
+      render json: {
+        token: token,
+        user: {
+          id: user.id,
+          email: user.email,
+          github_username: user.github_username,
+          qiita_username: user.qiita_username
+        }
+      }, status: :created
+    else
+      render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_params
+    params.permit(:email, :password, :password_confirmation, :github_username, :qiita_username)
+  end
+
+  # 開発環境用テストアクション
+  def test_token
+    test_user = User.first || User.create(
+      email: 'test@example.com',
+      password: 'password',
+      password_confirmation: 'password'
+    )
+    token = Auth.encode(user_id: test_user.id)
+    render json: {
+      token: token,
+      user: {
+        id: test_user.id,
+        email: test_user.email
+      }
+    }, status: :ok
   end
 end

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,0 +1,37 @@
+class Api::V1::ProfilesController < ApplicationController
+  def show
+    profile = current_user.profile
+
+    if profile
+      render json: profile, status: :ok
+    else
+      render json: { error: "Profile not found" }, status: :not_found
+    end
+  end
+
+  def create
+    result = CreateProfile.new(current_user, profile_params).execute
+
+    if result[:success]
+      render json: result[:profile], status: :created
+    else
+      render json: { errors: result[:errors] }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    result = UpdateProfile.new(current_user, profile_params).execute
+
+    if result[:success]
+      render json: result[:profile], status: :ok
+    else
+      render json: { errors: result[:errors] }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def profile_params
+    params.require(:profile).permit(:name, :bio, :avatar_url, :location, :website)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,8 @@ class User < ApplicationRecord
 
   validates :email, presence: true, uniqueness: true
   validates :password, length: { minimum: 6 }, allow_nil: true
+
+  def generate_token
+    Auth.encode(user_id: id)
+  end
 end

--- a/app/use_cases/update_profile.rb
+++ b/app/use_cases/update_profile.rb
@@ -10,7 +10,7 @@ class UpdateProfile
     profile = user.profile
 
     if profile.nil?
-      return { success: false, error: "Profile not found" }
+      return { success: false, errors: ["Profile not found"] }
     end
 
     if profile.update(params)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
       post "/login", to: "auth#login"
       post "/signup", to: "auth#signup"
 
+      resource :profile, only: [:show, :create, :update]
+
       # 開発環境のみのテスト用ルート
       if Rails.env.development?
         get "/test_token", to: "auth#test_token"

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -1,5 +1,10 @@
 FactoryBot.define do
   factory :profile do
-
+    user
+    name { Faker::Name.name }
+    bio { Faker::Lorem.paragraph }
+    avatar_url { Faker::Internet.url }
+    location { Faker::Address.city }
+    website { Faker::Internet.url }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,5 +5,11 @@ FactoryBot.define do
     password_confirmation { 'password123' }
     github_username { Faker::Internet.unique.username }
     qiita_username { Faker::Internet.unique.username }
+
+    trait :with_profile do
+      after(:create) do |user|
+        create(:profile, user: user)
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/profiles_spec.rb
+++ b/spec/requests/api/v1/profiles_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Profiles', type: :request do
+  let(:user) { create(:user) }
+  let(:headers) { { 'Authorization' => "Bearer #{user.generate_token}" } }
+  let(:valid_attributes) do
+    {
+      name: 'Test User',
+      bio: 'Test bio',
+      avatar_url: 'http://example.com/avatar.jpg'
+    }
+  end
+
+  describe 'POST /api/v1/profile' do
+    context 'with valid parameters' do
+      it 'creates a new profile' do
+        expect {
+          post '/api/v1/profile', params: { profile: valid_attributes }, headers: headers
+        }.to change(Profile, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(json_response['name']).to eq('Test User')
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'returns unprocessable entity status' do
+        post '/api/v1/profile', params: { profile: { name: '' } }, headers: headers
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response['errors']).to be_present
+      end
+    end
+  end
+
+  describe 'PATCH /api/v1/profile' do
+    let!(:profile) { create(:profile, user: user) }
+
+    context 'with valid parameters' do
+      it 'updates the profile' do
+        patch '/api/v1/profile', params: { profile: { name: 'Updated Name' } }, headers: headers
+        expect(response).to have_http_status(:ok)
+        expect(json_response['name']).to eq('Updated Name')
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'returns unprocessable entity status' do
+        patch '/api/v1/profile', params: { profile: { name: '' } }, headers: headers
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response['errors']).to be_present
+      end
+    end
+  end
+
+  def json_response
+    JSON.parse(response.body)
+  end
+end

--- a/spec/use_cases/create_profile_spec.rb
+++ b/spec/use_cases/create_profile_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe CreateProfile do
+  let(:user) { create(:user) }
+  let(:valid_params) do
+    {
+      name: 'Test User',
+      bio: 'Test bio',
+      avatar_url: 'http://example.com/avatar.jpg',
+      location: 'Tokyo',
+      website: 'http://example.com'
+    }
+  end
+
+  describe '#execute' do
+    context 'with valid params' do
+      it 'creates a profile' do
+        result = described_class.new(user, valid_params).execute
+
+        expect(result[:success]).to be true
+        expect(result[:profile]).to be_persisted
+        expect(user.profile).to be_present
+      end
+    end
+
+    context 'with invalid params' do
+      let(:invalid_params) { valid_params.merge(name: '') }
+
+      it 'returns errors' do
+        result = described_class.new(user, invalid_params).execute
+
+        expect(result[:success]).to be false
+        expect(result[:errors]).to include("Name can't be blank")
+      end
+    end
+  end
+end

--- a/spec/use_cases/update_profile_spec.rb
+++ b/spec/use_cases/update_profile_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe UpdateProfile do
+  let(:user) { create(:user, :with_profile) }
+
+  let(:valid_params) do
+    {
+      name: 'Updated Name',
+      bio: 'Updated bio',
+      avatar_url: 'http://example.com/new_avatar.jpg'
+    }
+  end
+
+  describe '#execute' do
+    context 'with valid params' do
+      it 'updates the profile' do
+        result = described_class.new(user, valid_params).execute
+
+        expect(result[:success]).to be true
+        expect(result[:profile].name).to eq('Updated Name')
+        expect(result[:profile].bio).to eq('Updated bio')
+        expect(result[:profile].avatar_url).to eq('http://example.com/new_avatar.jpg')
+      end
+    end
+
+    context 'with invalid params' do
+      let(:invalid_params) { valid_params.merge(name: '') }
+
+      it 'returns errors' do
+        result = described_class.new(user, invalid_params).execute
+
+        expect(result[:success]).to be false
+        expect(result[:errors]).to include("Name can't be blank")
+      end
+    end
+
+    context 'when profile does not exist' do
+      let(:user_without_profile) { create(:user) }
+
+      it 'returns error' do
+        result = described_class.new(user_without_profile, valid_params).execute
+
+        expect(result[:success]).to be false
+        expect(result[:errors]).to include('Profile not found')
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Userモデルにトークンを生成するメソッドを追加
- `error`を`errors`に統一。今後も統一して実装する予定。
- ProfileControllerを実装しshow, update, createメソッドを追加
- 以前実装したUseCaseと今回実装したProfileControllerのテストを記述

テストはすべて通過済