### PR TITLE
GitHubに関わる機能の実装

### DIFF
--- a/app/controllers/api/v1/github_activities_controller.rb
+++ b/app/controllers/api/v1/github_activities_controller.rb
@@ -1,0 +1,36 @@
+class Api::V1::GithubActivitiesController < ApplicationController
+  def index
+    activities = current_user.github_activities.order(activity_date: :desc)
+    render json: activities, status: :ok
+  end
+
+  def fetch
+    result = FetchGithubActivities.new(current_user).execute
+
+    if result[:success]
+      render json: result[:activities], status: :ok
+    else
+      render json: { errors: [ result[:errors] ] }, status: :unprocessable_entity
+    end
+  end
+
+  def repositories
+    activities = current_user.github_activities.where(activity_type: "Repository").order(activity_date: :desc)
+    render json: activities, status: :ok
+  end
+
+  def commits
+    activities = current_user.github_activities.where(activity_type: "Commit").order(activity_date: :desc)
+    render json: activities, status: :ok
+  end
+
+  def profile
+    result = FetchGithubProfile.new(current_user).execute
+
+    if result[:success]
+      render json: result[:profile], status: :ok
+    else
+      render json: { errors: result[:errors] }, status: :unprocessable_entity
+    end
+  end
+end

--- a/app/repositories/github_repository.rb
+++ b/app/repositories/github_repository.rb
@@ -1,0 +1,108 @@
+class GithubRepository
+  attr_reader :user
+
+  def initialize(user)
+    @user = user
+  end
+
+  def store_activities(activities_data)
+    return [] unless activities_data&.any?
+
+    activities = []
+
+    activities_data.each do |activity_data|
+      resource_id = activity_data["sha"] || activity_data["id"]
+      next unless resource_id.present?
+
+      activity = GithubActivity.find_or_initialize_by(
+        user: user,
+        github_id: resource_id.to_s
+      )
+
+      if activity_data["sha"] # コミットデータの場合
+        update_push_event(activity, activity_data)
+      elsif activity_data["type"] == "CreateEvent"
+        update_create_event(activity, activity_data)
+      elsif activity_data["type"] == "PullRequestEvent"
+        update_pull_request_event(activity, activity_data)
+      end
+
+      activities << activity if activity.save
+    end
+
+    activities
+  end
+
+  def store_repositories(repositories_data)
+    return [] unless repositories_data&.any?
+
+    activities = []
+
+    repositories_data.each do |repo_data|
+      activity = GithubActivity.find_or_initialize_by(
+        user: user,
+        github_id: repo_data["id"].to_s
+      )
+
+      activity.assign_attributes(
+        activity_type: "Repository",
+        repository_name: repo_data["name"],
+        repository_url: repo_data["html_url"],
+        description: repo_data["description"],
+        url: repo_data["html_url"],
+        activity_date: repo_data["created_at"]
+      )
+
+      activities << activity if activity.save
+    end
+
+    activities
+  end
+
+  def find_all_activities
+    user.github_activities.order(activity_date: :desc)
+  end
+
+  def find_activities_by_type(type)
+    user.github_activities.where(activity_type: type).order(activity_date: :desc)
+  end
+
+  private
+
+  def update_push_event(activity, activity_data)
+    repo_name = activity_data["repository"]&.dig("full_name") ||
+                activity_data.dig("repo", "name") ||
+                "unknown"
+
+    activity.assign_attributes(
+      activity_type: "Commit",
+      repository_name: repo_name.split("/").last,
+      repository_url: "https://github.com/#{repo_name}",
+      description: "Pushed #{activity_data.dig("payload", "size") || 'some'} commits",
+      url: "https://github.com/#{repo_name}/commits",
+      activity_date: activity_data["created_at"] || Time.current
+    )
+  end
+
+  def update_create_event(activity, activity_data)
+    activity.assign_attributes(
+      activity_type: "Repository",
+      repository_name: activity_data.dig("repo", "name")&.split("/")&.last,
+      repository_url: "https://github.com/#{activity_data.dig("repo", "name")}",
+      description: "Created #{activity_data.dig("payload", "ref_type")}",
+      url: "https://github.com/#{activity_data.dig("repo", "name")}",
+      activity_date: activity_data["created_at"]
+    )
+  end
+
+  def update_pull_request_event(activity, activity_data)
+    activity.assign_attributes(
+      activity_type: "PullRequest",
+      repository_name: activity_data.dig("repo", "name")&.split("/")&.last,
+      repository_url: "https://github.com/#{activity_data.dig("repo", "name")}",
+      description: "#{activity_data.dig("payload", "action")} pull request: #{activity_data.dig("payload", "pull_request", "title")}",
+      url: activity_data.dig("payload", "pull_request", "html_url"),
+      activity_date: activity_data["created_at"]
+    )
+  end
+end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -1,0 +1,48 @@
+require "json"
+require "net/http"
+require "uri"
+
+class GithubService
+  attr_reader :username
+
+  def initialize(username)
+    @username = username
+  end
+
+  def fetch_user_profile
+    response = make_request("users/#{username}")
+    response if response
+  end
+
+  def fetch_repositories
+    response = make_request("users/#{username}/repos")
+    response if response
+  end
+
+  def fetch_commits(repository)
+    response = make_request("repos/#{username}/#{repository}/commits")
+    response if response
+  end
+
+  private
+
+  def make_request(endpoint)
+    uri = URI.parse("https://api.github.com/#{endpoint}")
+    request = Net::HTTP::Get.new(uri)
+    request["Accept"] = "application/vnd.github.v3+json"
+    request["User-Agent"] = "RailsApp"
+
+    if ENV["GITHUB_ACCESS_TOKEN"].present?
+      request["Authorization"] = "token #{ENV['GITHUB_ACCESS_TOKEN']}"
+    end
+
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+      http.request(request)
+    end
+
+    return JSON.parse(response.body) if response.code == "200"
+
+    Rails.logger.error("GitHub API error: #{response.code} - #{response.body}")
+    nil
+  end
+end

--- a/app/use_cases/fetch_github_activities.rb
+++ b/app/use_cases/fetch_github_activities.rb
@@ -1,0 +1,29 @@
+class FetchGithubActivities
+  attr_reader :user, :github_service, :github_repository
+
+  def initialize(user)
+    @user = user
+    @github_service = GithubService.new(user.github_username)
+    @github_repository = GithubRepository.new(user)
+  end
+
+  def execute
+    return { success: false, errors: ["GitHub username not set"] } unless user.github_username.present?
+
+    repositories_data = github_service.fetch_repositories
+
+    if repositories_data
+      github_repository.store_repositories(repositories_data)
+
+      top_repos = repositories_data.sort_by { |repo| repo["stargazers_count"] }.reverse.take(3)
+      top_repos.each do |repo|
+        commits_data = github_service.fetch_commits(repo["name"])
+        github_repository.store_activities(commits_data) if commits_data
+      end
+
+      { success: true, activities: github_repository.find_all_activities}
+    else
+      { success: false, errors: ["Failed to fetch GitHub data"] }
+    end
+  end
+end

--- a/app/use_cases/fetch_github_profile.rb
+++ b/app/use_cases/fetch_github_profile.rb
@@ -1,0 +1,30 @@
+class FetchGithubProfile
+  attr_reader :user, :github_service
+
+  def initialize(user)
+    @user = user
+    @github_service = GithubService.new(user.github_username)
+  end
+
+  def execute
+    return { success: false, errors: ["GitHub username not set"] } unless user.github_username.present?
+
+    profile_data = github_service.fetch_user_profile
+
+    if profile_data
+      {
+        success: true,
+        profile: {
+          name: profile_data["name"],
+          bio: profile_data["bio"],
+          avatar_url: profile_data["avatar_url"],
+          public_repos: profile_data["public_repos"],
+          followers: profile_data["followers"],
+          following: profile_data["following"]
+        }
+      }
+    else
+      { success: false, errors: ["Failed to fetch GitHub profile"] }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,13 @@ Rails.application.routes.draw do
 
       resource :profile, only: [:show, :create, :update]
 
-      # 開発環境のみのテスト用ルート
-      if Rails.env.development?
-        get "/test_token", to: "auth#test_token"
+      resources :github_activities, only: [:index] do
+        collection do
+          get :fetch
+          get :repositories
+          get :commits
+          get :profile
+        end
       end
     end
   end

--- a/spec/factories/github_activities.rb
+++ b/spec/factories/github_activities.rb
@@ -1,5 +1,20 @@
 FactoryBot.define do
   factory :github_activity do
+    user
+    sequence(:github_id) { |n| "gh-#{n}" }
+    activity_type { %w[Repository Commit PullRequest].sample }
+    repository_name { Faker::App.name.parameterize }
+    repository_url { "https://github.com/#{Faker::Internet.username}/#{repository_name}" }
+    description { Faker::Lorem.sentence }
+    url { repository_url }
+    activity_date { Faker::Time.between(from: 1.year.ago, to: Time.current) }
 
+    trait :repository do
+      activity_type { "Repository" }
+    end
+
+    trait :commit do
+      activity_type { "Commit" }
+    end
   end
 end

--- a/spec/models/github_activity_spec.rb
+++ b/spec/models/github_activity_spec.rb
@@ -1,5 +1,43 @@
 require 'rails_helper'
 
 RSpec.describe GithubActivity, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+  let(:valid_attributes) {
+    {
+      user: user,
+      github_id: "12345",
+      activity_type: "Repository",
+      repository_name: "test-repo",
+      repository_url: "https://github.com/test/test-repo",
+      description: "Test repository",
+      url: "https://github.com/test/test-repo",
+      activity_date: Time.current
+    }
+  }
+
+  it "is valid with valid attributes" do
+    activity = GithubActivity.new(valid_attributes)
+    expect(activity).to be_valid
+  end
+
+  it "is not valid without a user" do
+    activity = GithubActivity.new(valid_attributes.except(:user))
+    expect(activity).not_to be_valid
+  end
+
+  it "is not valid without a github_id" do
+    activity = GithubActivity.new(valid_attributes.except(:github_id))
+    expect(activity).not_to be_valid
+  end
+
+  it "is not valid without an activity_type" do
+    activity = GithubActivity.new(valid_attributes.except(:activity_type))
+    expect(activity).not_to be_valid
+  end
+
+  it "has unique github_id per user" do
+    GithubActivity.create!(valid_attributes)
+    duplicate = GithubActivity.new(valid_attributes)
+    expect(duplicate).not_to be_valid
+  end
 end

--- a/spec/requests/api/v1/github_activities_spec.rb
+++ b/spec/requests/api/v1/github_activities_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::GithubActivities", type: :request do
+  let(:user) { create(:user) }
+  let(:headers) { { 'Authorization' => "Bearer #{user.generate_token}" } }
+
+  describe "GET /api/v1/github_activities" do
+    let!(:activity1) { create(:github_activity, user: user, activity_date: 1.day.ago) }
+    let!(:activity2) { create(:github_activity, user: user, activity_date: 2.days.ago) }
+
+    it "returns all activities ordered by date" do
+      get api_v1_github_activities_path, headers: headers
+      expect(response).to have_http_status(:ok)
+      expect(json_response.size).to eq 2
+      expect(json_response.first['id']).to eq activity1.id
+      expect(json_response.last['id']).to eq activity2.id
+    end
+  end
+
+  describe "GET /api/v1/github_activities/repositories" do
+    let!(:repo_activity) { create(:github_activity, :repository, user: user) }
+    let!(:commit_activity) { create(:github_activity, :commit, user: user) }
+
+    it "returns only repository activities" do
+      get repositories_api_v1_github_activities_path, headers: headers
+      expect(response).to have_http_status(:ok)
+      expect(json_response.size).to eq 1
+      expect(json_response.first['activity_type']).to eq 'Repository'
+    end
+  end
+
+  describe "GET /api/v1/github_activities/commits" do
+    let!(:repo_activity) { create(:github_activity, :repository, user: user) }
+    let!(:commit_activity) { create(:github_activity, :commit, user: user) }
+
+    it "returns only commit activities" do
+      get commits_api_v1_github_activities_path, headers: headers
+      expect(response).to have_http_status(:ok)
+      expect(json_response.size).to eq 1
+      expect(json_response.first['activity_type']).to eq 'Commit'
+    end
+  end
+
+  describe "GET /api/v1/github_activities/profile" do
+    context "when GitHub username is set" do
+      before do
+        allow_any_instance_of(GithubService).to receive(:fetch_user_profile).and_return({
+          "name" => "Test User",
+          "bio" => "Test bio",
+          "avatar_url" => "http://example.com/avatar.jpg",
+          "public_repos" => 10,
+          "followers" => 100,
+          "following" => 50
+        })
+      end
+
+      it "returns GitHub profile data" do
+        get profile_api_v1_github_activities_path, headers: headers
+        expect(response).to have_http_status(:ok)
+        expect(json_response["name"]).to eq "Test User"
+        expect(json_response["bio"]).to eq "Test bio"
+      end
+    end
+
+    context "when GitHub username is not set" do
+      let(:user) { create(:user, github_username: nil) }
+
+      it "returns error" do
+        get profile_api_v1_github_activities_path, headers: headers
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response["errors"]).to include("GitHub username not set")
+      end
+    end
+  end
+
+  def json_response
+    JSON.parse(response.body)
+  end
+end

--- a/spec/use_cases/fetch_github_activities_spec.rb
+++ b/spec/use_cases/fetch_github_activities_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe FetchGithubActivities do
+  let(:user) { create(:user, github_username: 'testuser') }
+  let(:github_service) { instance_double(GithubService) }
+  let(:github_repository) { instance_double(GithubRepository) }
+  let(:repositories_data) do
+    [
+      { "id" => 1, "name" => "repo1", "stargazers_count" => 10, "html_url" => "http://github.com/repo1", "description" => "Test repo", "created_at" => Time.current.to_s },
+      { "id" => 2, "name" => "repo2", "stargazers_count" => 5, "html_url" => "http://github.com/repo2", "description" => "Test repo 2", "created_at" => Time.current.to_s }
+    ]
+  end
+  let(:commits_data) do
+    [
+      { "sha" => "abc123", "repository" => { "full_name" => "testuser/repo1" }, "created_at" => Time.current.to_s }
+    ]
+  end
+
+  before do
+    allow(GithubService).to receive(:new).and_return(github_service)
+    allow(GithubRepository).to receive(:new).and_return(github_repository)
+  end
+
+  describe '#execute' do
+    context 'when GitHub username is present' do
+      before do
+        allow(github_service).to receive(:fetch_repositories).and_return(repositories_data)
+        allow(github_service).to receive(:fetch_commits).and_return(commits_data)
+        allow(github_repository).to receive(:store_repositories)
+        allow(github_repository).to receive(:store_activities)
+        allow(github_repository).to receive(:find_all_activities).and_return([])
+      end
+
+      it 'returns success with activities' do
+        result = described_class.new(user).execute
+
+        expect(result[:success]).to be true
+        expect(result[:activities]).to eq([])
+      end
+
+      it 'fetches repositories from GitHub' do
+        described_class.new(user).execute
+        expect(github_service).to have_received(:fetch_repositories)
+      end
+
+      it 'stores repositories data' do
+        described_class.new(user).execute
+        expect(github_repository).to have_received(:store_repositories).with(repositories_data)
+      end
+    end
+
+    context 'when GitHub username is blank' do
+      let(:user) { create(:user, github_username: nil) }
+
+      it 'returns error' do
+        result = described_class.new(user).execute
+
+        expect(result[:success]).to be false
+        expect(result[:errors]).to include("GitHub username not set")
+      end
+    end
+
+    context 'when GitHub API fails' do
+      before do
+        allow(github_service).to receive(:fetch_repositories).and_return(nil)
+      end
+
+      it 'returns error' do
+        result = described_class.new(user).execute
+
+        expect(result[:success]).to be false
+        expect(result[:errors]).to include("Failed to fetch GitHub data")
+      end
+    end
+  end
+end


### PR DESCRIPTION
- サービス層の実装
ユーザーを特定し、GituHubからプロフィール、リポジトリ、コミットを取得する実装
1fc9424dfb478b50c3585e6574f50b9bb84a26d5

- リポジトリ層の実装
取得した`GithubActivity`を保存するリポジトリ層の実装
9c402fd7182dd7d8d164cd011a8f4575e0011ba3

- ユースケース層の実装
`GithubActivity`とGithubの`Profile`を取得するユースケースの実装
7be216cdef5bc9ab56c49aed86e5c32836d3d570

- コントローラーの実装
モデルから情報を取得する`index, repositories, commits`の実装
UseCase経由でGitHubから情報を取得する`fetch(repositoriesの取得), profile(GitHubのProfileの取得)`の実装
27898c2cc3840cb8664fb8c24b7b5d24a451ec12

- ルーティング、テストの実装
f073e920670034b16404eefd3d4b0634e3e1304c
7fca3319ebdedef3540e96c44da39f6aa5c2064e
